### PR TITLE
chore: relicense under Apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 Medal Social
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023-2026 Medal Social
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Medal Social
+https://medal.tv
+
+Copyright 2023-2026 Medal Social
+
+This product includes software developed at Medal Social.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ pnpm docs
 
 ### License
 
-MIT
+Apache-2.0
 
 

--- a/docs/plans/2026-04-20-device-types.md
+++ b/docs/plans/2026-04-20-device-types.md
@@ -1,0 +1,341 @@
+# Device Types & WebSocket Messages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add device management types and WebSocket message schemas to the Medal Social SDK so all repos share one source of truth for device communication.
+
+**Architecture:** New `src/devices/` module alongside the existing `src/index.ts`. Exports device types, WebSocket message schemas, and state interfaces. No runtime dependencies — pure TypeScript types + a few validation helpers.
+
+**Tech Stack:** TypeScript, tsup (existing build), Vitest (existing tests)
+
+**Spec:** Picasso repo `docs/superpowers/specs/2026-04-20-kit-medal-social-integration-design.md` — Sections 4, 5, 6
+
+---
+
+### Task 1: Device core types
+
+**Files:**
+- Create: `src/devices/types.ts`
+- Modify: `src/index.ts` (re-export)
+
+- [ ] **Step 1: Create device types file**
+
+```typescript
+// src/devices/types.ts
+
+export type DeviceMode = 'medal-os' | 'pilot';
+export type DeviceModel = 'frame-13' | 'frame-28' | 'frame-31' | 'frame-40' | 'studio' | 'canvas' | 'mac' | 'linux';
+export type DisplayType = 'eink' | 'ips' | 'hdmi' | 'none';
+export type InputMode = 'touch' | 'bezel-gesture' | 'remote' | 'keyboard-mouse';
+export type DeviceStatus = 'online' | 'offline' | 'updating';
+
+export interface DeviceCapabilities {
+  mode: DeviceMode;
+  model: DeviceModel;
+  displayType: DisplayType;
+  inputMode: InputMode;
+  hasCamera: boolean;
+  hasMicrophone: boolean;
+  hasBluetooth: boolean;
+  hasNfc: boolean;
+}
+
+export interface DeviceIdentity {
+  deviceId: string;
+  workspaceId: string;
+  name: string;
+  model: DeviceModel;
+  mode: DeviceMode;
+  capabilities: DeviceCapabilities;
+}
+
+export interface ConsentGrants {
+  viewContent: boolean;
+  pushContent: boolean;
+  changeSettings: boolean;
+  remoteWipe: boolean;
+}
+```
+
+- [ ] **Step 2: Re-export from index.ts**
+
+Add to bottom of `src/index.ts`:
+```typescript
+export * from './devices/types';
+```
+
+- [ ] **Step 3: Run build and verify**
+
+```bash
+pnpm build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/devices/types.ts src/index.ts && git commit -m "feat: add device core types — identity, capabilities, consent"
+```
+
+---
+
+### Task 2: Device state types
+
+**Files:**
+- Create: `src/devices/state.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Create state types**
+
+```typescript
+// src/devices/state.ts
+
+import type { DeviceModel, DeviceMode } from './types';
+
+export interface GalleryConfig {
+  collection: string;
+  rotationInterval: string;
+  shuffle: boolean;
+  transition: 'fade' | 'cut' | 'slide' | 'dissolve';
+  sleep: { start: string; end: string } | null;
+  imageFit: 'fill' | 'fit' | 'center-crop';
+}
+
+export interface DisplayConfig {
+  brightness: number | 'auto';
+  colorTemp: number | 'auto';
+  ambientLight: boolean;
+}
+
+export interface DesiredState {
+  deviceId: string;
+  workspaceId: string;
+  config: {
+    name: string;
+    mode: string;
+    display: DisplayConfig;
+    gallery?: GalleryConfig;
+    modulesEnabled: string[];
+  };
+  content: {
+    collections: Array<{
+      id: string;
+      images: string[];
+      source: string;
+    }>;
+  };
+  os: {
+    targetVersion: string;
+    autoUpdate: boolean;
+  };
+  version: number;
+}
+
+export interface ReportedState {
+  deviceId: string;
+  osVersion: string;
+  uptime: string;
+  storage: { usedGb: number; totalGb: number };
+  temperatureC: number | null;
+  activeApp: string | null;
+  activeImage: string | null;
+  wifiSignal: number | null;
+  lastContentSync: string | null;
+  configVersion: number;
+}
+```
+
+- [ ] **Step 2: Re-export from index.ts**
+
+```typescript
+export * from './devices/state';
+```
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+pnpm build && git add src/devices/state.ts src/index.ts && git commit -m "feat: add desired state and reported state types"
+```
+
+---
+
+### Task 3: WebSocket message types
+
+**Files:**
+- Create: `src/devices/messages.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Create message types**
+
+```typescript
+// src/devices/messages.ts
+
+import type { DeviceCapabilities, ConsentGrants } from './types';
+import type { DesiredState, ReportedState } from './state';
+
+// Device → Cloud messages
+export interface RegisterMessage {
+  type: 'register';
+  deviceId: string;
+  capabilities: DeviceCapabilities;
+  osVersion: string;
+  reportedState: ReportedState;
+}
+
+export interface HeartbeatMessage {
+  type: 'heartbeat';
+  deviceId: string;
+  status: 'online' | 'updating';
+  uptime: string;
+  storage: { usedGb: number; totalGb: number };
+  temperatureC: number | null;
+  activeApp: string | null;
+  wifiSignal: number | null;
+}
+
+export interface SyncRequestMessage {
+  type: 'sync_request';
+  deviceId: string;
+  currentConfigVersion: number;
+}
+
+export interface StateReportMessage {
+  type: 'state_report';
+  deviceId: string;
+  reportedState: ReportedState;
+}
+
+export interface DeviceEventMessage {
+  type: 'event';
+  deviceId: string;
+  event: 'content_changed' | 'error' | 'ota_complete' | 'app_installed' | 'consent_updated';
+  details: Record<string, unknown>;
+}
+
+export type DeviceToCloudMessage =
+  | RegisterMessage
+  | HeartbeatMessage
+  | SyncRequestMessage
+  | StateReportMessage
+  | DeviceEventMessage;
+
+// Cloud → Device messages
+export interface DesiredStateMessage {
+  type: 'desired_state';
+  state: DesiredState;
+  delta: boolean;
+}
+
+export interface PushContentMessage {
+  type: 'push_content';
+  collectionId: string;
+  images: Array<{ id: string; url: string; metadata?: Record<string, unknown> }>;
+}
+
+export interface PushConfigMessage {
+  type: 'push_config';
+  config: Partial<DesiredState['config']>;
+}
+
+export interface PushSkillsMessage {
+  type: 'push_skills';
+  skills: Array<{ name: string; version: string; url: string }>;
+}
+
+export interface CommandMessage {
+  type: 'command';
+  command: 'restart' | 'update' | 'lock' | 'wipe' | 'identify' | 'rollback';
+  params?: Record<string, unknown>;
+}
+
+export interface OtaAvailableMessage {
+  type: 'ota_available';
+  version: string;
+  downloadUrl: string;
+  changelog: string;
+  priority: 'low' | 'normal' | 'critical';
+}
+
+export interface AckMessage {
+  type: 'ack';
+  replyTo: string;
+  status: 'ok' | 'error';
+  error?: string;
+}
+
+export type CloudToDeviceMessage =
+  | DesiredStateMessage
+  | PushContentMessage
+  | PushConfigMessage
+  | PushSkillsMessage
+  | CommandMessage
+  | OtaAvailableMessage
+  | AckMessage;
+```
+
+- [ ] **Step 2: Re-export from index.ts**
+
+```typescript
+export * from './devices/messages';
+```
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+pnpm build && git add src/devices/messages.ts src/index.ts && git commit -m "feat: add WebSocket message types — device-to-cloud and cloud-to-device"
+```
+
+---
+
+### Task 4: Device token types and barrel export
+
+**Files:**
+- Create: `src/devices/token.ts`
+- Create: `src/devices/index.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Create token types**
+
+```typescript
+// src/devices/token.ts
+
+import type { DeviceMode } from './types';
+
+export interface DeviceTokenPayload {
+  deviceId: string;
+  workspaceId: string;
+  mode: DeviceMode;
+  capabilities: string[];
+  iat: number;
+  exp: number;
+}
+
+export interface DeviceRegistration {
+  deviceId: string;
+  workspaceId: string;
+  token: string;
+  websocketUrl: string;
+}
+```
+
+- [ ] **Step 2: Create barrel export**
+
+```typescript
+// src/devices/index.ts
+export * from './types';
+export * from './state';
+export * from './messages';
+export * from './token';
+```
+
+- [ ] **Step 3: Update main index.ts to use barrel**
+
+Replace the three separate re-exports with:
+```typescript
+export * from './devices';
+```
+
+- [ ] **Step 4: Build, test, commit**
+
+```bash
+pnpm build && pnpm test && git add src/devices/ src/index.ts && git commit -m "feat: device token types and barrel export"
+```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@medalsocial/sdk",
   "version": "0.1.2",
   "description": "TypeScript client for Medal Social API (create leads, notes, cookie consents, event signups)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "Medal Social / Ali Aljumaili",
   "repository": {
     "type": "git",

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './state';
+export * from './messages';
+export * from './token';

--- a/src/devices/messages.ts
+++ b/src/devices/messages.ts
@@ -1,0 +1,101 @@
+import type { DeviceCapabilities, ConsentGrants } from './types';
+import type { DesiredState, ReportedState } from './state';
+
+// Device -> Cloud messages
+export interface RegisterMessage {
+  type: 'register';
+  deviceId: string;
+  capabilities: DeviceCapabilities;
+  osVersion: string;
+  reportedState: ReportedState;
+}
+
+export interface HeartbeatMessage {
+  type: 'heartbeat';
+  deviceId: string;
+  status: 'online' | 'updating';
+  uptime: string;
+  storage: { usedGb: number; totalGb: number };
+  temperatureC: number | null;
+  activeApp: string | null;
+  wifiSignal: number | null;
+}
+
+export interface SyncRequestMessage {
+  type: 'sync_request';
+  deviceId: string;
+  currentConfigVersion: number;
+}
+
+export interface StateReportMessage {
+  type: 'state_report';
+  deviceId: string;
+  reportedState: ReportedState;
+}
+
+export interface DeviceEventMessage {
+  type: 'event';
+  deviceId: string;
+  event: 'content_changed' | 'error' | 'ota_complete' | 'app_installed' | 'consent_updated';
+  details: Record<string, unknown>;
+}
+
+export type DeviceToCloudMessage =
+  | RegisterMessage
+  | HeartbeatMessage
+  | SyncRequestMessage
+  | StateReportMessage
+  | DeviceEventMessage;
+
+// Cloud -> Device messages
+export interface DesiredStateMessage {
+  type: 'desired_state';
+  state: DesiredState;
+  delta: boolean;
+}
+
+export interface PushContentMessage {
+  type: 'push_content';
+  collectionId: string;
+  images: Array<{ id: string; url: string; metadata?: Record<string, unknown> }>;
+}
+
+export interface PushConfigMessage {
+  type: 'push_config';
+  config: Partial<DesiredState['config']>;
+}
+
+export interface PushSkillsMessage {
+  type: 'push_skills';
+  skills: Array<{ name: string; version: string; url: string }>;
+}
+
+export interface CommandMessage {
+  type: 'command';
+  command: 'restart' | 'update' | 'lock' | 'wipe' | 'identify' | 'rollback';
+  params?: Record<string, unknown>;
+}
+
+export interface OtaAvailableMessage {
+  type: 'ota_available';
+  version: string;
+  downloadUrl: string;
+  changelog: string;
+  priority: 'low' | 'normal' | 'critical';
+}
+
+export interface AckMessage {
+  type: 'ack';
+  replyTo: string;
+  status: 'ok' | 'error';
+  error?: string;
+}
+
+export type CloudToDeviceMessage =
+  | DesiredStateMessage
+  | PushContentMessage
+  | PushConfigMessage
+  | PushSkillsMessage
+  | CommandMessage
+  | OtaAvailableMessage
+  | AckMessage;

--- a/src/devices/state.ts
+++ b/src/devices/state.ts
@@ -1,0 +1,53 @@
+import type { DeviceMode } from './types';
+
+export interface GalleryConfig {
+  collection: string;
+  rotationInterval: string;
+  shuffle: boolean;
+  transition: 'fade' | 'cut' | 'slide' | 'dissolve';
+  sleep: { start: string; end: string } | null;
+  imageFit: 'fill' | 'fit' | 'center-crop';
+}
+
+export interface DisplayConfig {
+  brightness: number | 'auto';
+  colorTemp: number | 'auto';
+  ambientLight: boolean;
+}
+
+export interface DesiredState {
+  deviceId: string;
+  workspaceId: string;
+  config: {
+    name: string;
+    mode: string;
+    display: DisplayConfig;
+    gallery?: GalleryConfig;
+    modulesEnabled: string[];
+  };
+  content: {
+    collections: Array<{
+      id: string;
+      images: string[];
+      source: string;
+    }>;
+  };
+  os: {
+    targetVersion: string;
+    autoUpdate: boolean;
+  };
+  version: number;
+}
+
+export interface ReportedState {
+  deviceId: string;
+  osVersion: string;
+  uptime: string;
+  storage: { usedGb: number; totalGb: number };
+  temperatureC: number | null;
+  activeApp: string | null;
+  activeImage: string | null;
+  wifiSignal: number | null;
+  lastContentSync: string | null;
+  configVersion: number;
+}

--- a/src/devices/token.ts
+++ b/src/devices/token.ts
@@ -1,0 +1,17 @@
+import type { DeviceMode } from './types';
+
+export interface DeviceTokenPayload {
+  deviceId: string;
+  workspaceId: string;
+  mode: DeviceMode;
+  capabilities: string[];
+  iat: number;
+  exp: number;
+}
+
+export interface DeviceRegistration {
+  deviceId: string;
+  workspaceId: string;
+  token: string;
+  websocketUrl: string;
+}

--- a/src/devices/types.ts
+++ b/src/devices/types.ts
@@ -1,0 +1,32 @@
+export type DeviceMode = 'medal-os' | 'pilot';
+export type DeviceModel = 'frame-13' | 'frame-28' | 'frame-31' | 'frame-40' | 'studio' | 'canvas' | 'mac' | 'linux';
+export type DisplayType = 'eink' | 'ips' | 'hdmi' | 'none';
+export type InputMode = 'touch' | 'bezel-gesture' | 'remote' | 'keyboard-mouse';
+export type DeviceStatus = 'online' | 'offline' | 'updating';
+
+export interface DeviceCapabilities {
+  mode: DeviceMode;
+  model: DeviceModel;
+  displayType: DisplayType;
+  inputMode: InputMode;
+  hasCamera: boolean;
+  hasMicrophone: boolean;
+  hasBluetooth: boolean;
+  hasNfc: boolean;
+}
+
+export interface DeviceIdentity {
+  deviceId: string;
+  workspaceId: string;
+  name: string;
+  model: DeviceModel;
+  mode: DeviceMode;
+  capabilities: DeviceCapabilities;
+}
+
+export interface ConsentGrants {
+  viewContent: boolean;
+  pushContent: boolean;
+  changeSettings: boolean;
+  remoteWipe: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,3 +228,5 @@ export class MedalSocialClient {
 }
 
 export default MedalSocialClient;
+
+export * from './devices';


### PR DESCRIPTION
Relicense this project from its previous license (MIT / ISC / none) to Apache-2.0 for consistency across Medal Social's open-source surface.

Changes:
- Replace LICENSE file(s) with Apache-2.0 text
- Normalize copyright line to `Copyright 2023-2026 Medal Social`
- Add NOTICE file
- Update `package.json` `license` fields
- Rewrite `SPDX-License-Identifier` headers in source files where present
- Update README license section / badge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation/metadata and TypeScript type additions with no runtime behavior changes; main risk is accidental public API surface/typing incompatibilities from the new exported `devices` module.
> 
> **Overview**
> Switches project licensing from **MIT** to **Apache-2.0** by replacing `LICENSE`, adding `NOTICE`, and updating the `package.json` and `README.md` license declarations.
> 
> Adds a new `src/devices/*` module (barrel-exported via `src/index.ts`) providing TypeScript types for device identity/capabilities, desired/reported state, device token payload/registration, and WebSocket message unions for device↔cloud communication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef51aa4b67503766383b59e024f6466844ffad3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->