### PR TITLE
feat: add Pilot integration — plugin.toml + createMedalTools factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./pilot": {
+      "types": "./dist/pilot/index.d.ts",
+      "import": "./dist/pilot/index.mjs",
+      "require": "./dist/pilot/index.js"
     }
   },
   "sideEffects": false,
@@ -28,7 +33,8 @@
   },
   "packageManager": "pnpm@10.16.0",
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs --sourcemap",
+    "build": "tsup src/index.ts pilot/index.ts --dts --format esm,cjs --sourcemap",
+    "typecheck": "tsc --noEmit",
     "dev": "tsup src/index.ts --watch",
     "clean": "rm -rf dist",
     "prepare": "husky",
@@ -44,6 +50,9 @@
   },
   "files": ["dist"],
   "keywords": ["medal", "social", "sdk", "api", "typescript", "client"],
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "@types/node": "^24.3.2",
     "@vitest/coverage-v8": "^2.0.5",

--- a/pilot/index.test.ts
+++ b/pilot/index.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
-import { z } from 'zod';
-import { createMedalTools } from './index.js';
-import type { MedalSocialClient } from '../src/index.js';
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { MedalSocialClient } from "../src/index.js";
+import { createMedalTools } from "./index.js";
 
 const mockClient = {
   createLead: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
@@ -12,39 +12,44 @@ const mockClient = {
   sendTransactionalEmail: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
 } as unknown as MedalSocialClient;
 
-describe('createMedalTools', () => {
-  it('returns an object with all 6 tools', () => {
+describe("createMedalTools", () => {
+  it("returns an object with all 6 tools", () => {
     const tools = createMedalTools(mockClient);
     expect(Object.keys(tools)).toHaveLength(6);
-    expect(tools).toHaveProperty('createLead');
-    expect(tools).toHaveProperty('createContactNote');
-    expect(tools).toHaveProperty('createCookieConsent');
-    expect(tools).toHaveProperty('createEventSignup');
-    expect(tools).toHaveProperty('createNote');
-    expect(tools).toHaveProperty('sendTransactionalEmail');
+    expect(tools).toHaveProperty("createLead");
+    expect(tools).toHaveProperty("createContactNote");
+    expect(tools).toHaveProperty("createCookieConsent");
+    expect(tools).toHaveProperty("createEventSignup");
+    expect(tools).toHaveProperty("createNote");
+    expect(tools).toHaveProperty("sendTransactionalEmail");
   });
 
-  it('each tool has description, parameters (ZodSchema), and execute', () => {
+  it("each tool has description, parameters (ZodSchema), and execute", () => {
     const tools = createMedalTools(mockClient);
     for (const [, tool] of Object.entries(tools)) {
-      expect(tool).toHaveProperty('description');
-      expect(typeof tool.description).toBe('string');
-      expect(tool).toHaveProperty('parameters');
+      expect(tool).toHaveProperty("description");
+      expect(typeof tool.description).toBe("string");
+      expect(tool).toHaveProperty("parameters");
       expect(tool.parameters).toBeInstanceOf(z.ZodObject);
-      expect(tool).toHaveProperty('execute');
-      expect(typeof tool.execute).toBe('function');
+      expect(tool).toHaveProperty("execute");
+      expect(typeof tool.execute).toBe("function");
     }
   });
 
-  it('createLead tool calls client.createLead with parsed args', async () => {
+  it("createLead tool calls client.createLead with parsed args", async () => {
     const tools = createMedalTools(mockClient);
-    await tools.createLead.execute({ items: [{ name: 'Alice', email: 'alice@example.com' }] });
-    expect(mockClient.createLead).toHaveBeenCalledWith([{ name: 'Alice', email: 'alice@example.com' }]);
+    await tools.createLead.execute({ items: [{ name: "Alice", email: "alice@example.com" }] });
+    expect(mockClient.createLead).toHaveBeenCalledWith([
+      { name: "Alice", email: "alice@example.com" },
+    ]);
   });
 
-  it('sendTransactionalEmail tool calls client.sendTransactionalEmail', async () => {
+  it("sendTransactionalEmail tool calls client.sendTransactionalEmail", async () => {
     const tools = createMedalTools(mockClient);
-    await tools.sendTransactionalEmail.execute({ to: 'a@b.com', slug: 'welcome' });
-    expect(mockClient.sendTransactionalEmail).toHaveBeenCalledWith({ to: 'a@b.com', slug: 'welcome' });
+    await tools.sendTransactionalEmail.execute({ to: "a@b.com", slug: "welcome" });
+    expect(mockClient.sendTransactionalEmail).toHaveBeenCalledWith({
+      to: "a@b.com",
+      slug: "welcome",
+    });
   });
 });

--- a/pilot/index.test.ts
+++ b/pilot/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { createMedalTools } from './index.js';
+import type { MedalSocialClient } from '../src/index.js';
+
+const mockClient = {
+  createLead: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
+  createContactNote: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
+  createCookieConsent: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
+  createEventSignup: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
+  createNote: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
+  sendTransactionalEmail: vi.fn().mockResolvedValue({ status: 200, data: {}, headers: {} }),
+} as unknown as MedalSocialClient;
+
+describe('createMedalTools', () => {
+  it('returns an object with all 6 tools', () => {
+    const tools = createMedalTools(mockClient);
+    expect(Object.keys(tools)).toHaveLength(6);
+    expect(tools).toHaveProperty('createLead');
+    expect(tools).toHaveProperty('createContactNote');
+    expect(tools).toHaveProperty('createCookieConsent');
+    expect(tools).toHaveProperty('createEventSignup');
+    expect(tools).toHaveProperty('createNote');
+    expect(tools).toHaveProperty('sendTransactionalEmail');
+  });
+
+  it('each tool has description, parameters (ZodSchema), and execute', () => {
+    const tools = createMedalTools(mockClient);
+    for (const [, tool] of Object.entries(tools)) {
+      expect(tool).toHaveProperty('description');
+      expect(typeof tool.description).toBe('string');
+      expect(tool).toHaveProperty('parameters');
+      expect(tool.parameters).toBeInstanceOf(z.ZodObject);
+      expect(tool).toHaveProperty('execute');
+      expect(typeof tool.execute).toBe('function');
+    }
+  });
+
+  it('createLead tool calls client.createLead with parsed args', async () => {
+    const tools = createMedalTools(mockClient);
+    await tools.createLead.execute({ items: [{ name: 'Alice', email: 'alice@example.com' }] });
+    expect(mockClient.createLead).toHaveBeenCalledWith([{ name: 'Alice', email: 'alice@example.com' }]);
+  });
+
+  it('sendTransactionalEmail tool calls client.sendTransactionalEmail', async () => {
+    const tools = createMedalTools(mockClient);
+    await tools.sendTransactionalEmail.execute({ to: 'a@b.com', slug: 'welcome' });
+    expect(mockClient.sendTransactionalEmail).toHaveBeenCalledWith({ to: 'a@b.com', slug: 'welcome' });
+  });
+});

--- a/pilot/index.ts
+++ b/pilot/index.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import type { MedalSocialClient } from '../src/index.js';
+
+const LeadItemSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  company: z.string().optional(),
+  source: z.string().optional(),
+});
+
+const ContactNoteSchema = z.object({
+  contactId: z.string(),
+  note: z.string(),
+});
+
+const CookieConsentSchema = z.object({
+  domain: z.string(),
+  consentStatus: z.enum(['granted', 'denied', 'partial']),
+  consentTimestamp: z.string(),
+  ipAddress: z.string().optional(),
+  userAgent: z.string().optional(),
+  cookiePreferences: z.object({
+    necessary: z.object({ allowed: z.boolean() }).optional(),
+    analytics: z.object({ allowed: z.boolean() }).optional(),
+    marketing: z.object({ allowed: z.boolean() }).optional(),
+    functional: z.object({ allowed: z.boolean() }).optional(),
+  }),
+});
+
+const EventSignupSchema = z.object({
+  contact: z.object({
+    name: z.string(),
+    email: z.string().email(),
+    company: z.string().optional(),
+  }),
+  event: z.object({
+    externalId: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    time: z.string(),
+    location: z.string().optional(),
+    thumbnail: z.string().optional(),
+  }),
+});
+
+const NoteSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  company: z.string().optional(),
+  phone: z.string().optional(),
+  content: z.string().optional(),
+});
+
+const TransactionalEmailSchema = z.object({
+  to: z.string().email(),
+  slug: z.string(),
+  additionalData: z.record(z.unknown()).optional(),
+});
+
+export function createMedalTools(client: MedalSocialClient) {
+  return {
+    createLead: {
+      description: 'Create one or more leads in Medal Social CRM',
+      parameters: z.object({ items: z.array(LeadItemSchema) }),
+      execute: async (args: { items: z.infer<typeof LeadItemSchema>[] }) =>
+        client.createLead(args.items),
+    },
+    createContactNote: {
+      description: 'Attach a note to a contact by ID',
+      parameters: ContactNoteSchema,
+      execute: async (args: z.infer<typeof ContactNoteSchema>) =>
+        client.createContactNote(args),
+    },
+    createCookieConsent: {
+      description: "Record a user's cookie consent preferences",
+      parameters: CookieConsentSchema,
+      execute: async (args: z.infer<typeof CookieConsentSchema>) =>
+        client.createCookieConsent(args),
+    },
+    createEventSignup: {
+      description: 'Create an event signup with contact and event details',
+      parameters: EventSignupSchema,
+      execute: async (args: z.infer<typeof EventSignupSchema>) =>
+        client.createEventSignup(args),
+    },
+    createNote: {
+      description: 'Create a free-form note for inbound messages',
+      parameters: NoteSchema,
+      execute: async (args: z.infer<typeof NoteSchema>) =>
+        client.createNote(args),
+    },
+    sendTransactionalEmail: {
+      description: 'Send a transactional email by template slug',
+      parameters: TransactionalEmailSchema,
+      execute: async (args: z.infer<typeof TransactionalEmailSchema>) =>
+        client.sendTransactionalEmail(args),
+    },
+  };
+}

--- a/pilot/index.ts
+++ b/pilot/index.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
-import type { MedalSocialClient } from '../src/index.js';
+import { z } from "zod";
+import type { MedalSocialClient } from "../src/index.js";
 
 const LeadItemSchema = z.object({
   name: z.string(),
@@ -15,7 +15,7 @@ const ContactNoteSchema = z.object({
 
 const CookieConsentSchema = z.object({
   domain: z.string(),
-  consentStatus: z.enum(['granted', 'denied', 'partial']),
+  consentStatus: z.enum(["granted", "denied", "partial"]),
   consentTimestamp: z.string(),
   ipAddress: z.string().optional(),
   userAgent: z.string().optional(),
@@ -62,16 +62,15 @@ const TransactionalEmailSchema = z.object({
 export function createMedalTools(client: MedalSocialClient) {
   return {
     createLead: {
-      description: 'Create one or more leads in Medal Social CRM',
+      description: "Create one or more leads in Medal Social CRM",
       parameters: z.object({ items: z.array(LeadItemSchema) }),
       execute: async (args: { items: z.infer<typeof LeadItemSchema>[] }) =>
         client.createLead(args.items),
     },
     createContactNote: {
-      description: 'Attach a note to a contact by ID',
+      description: "Attach a note to a contact by ID",
       parameters: ContactNoteSchema,
-      execute: async (args: z.infer<typeof ContactNoteSchema>) =>
-        client.createContactNote(args),
+      execute: async (args: z.infer<typeof ContactNoteSchema>) => client.createContactNote(args),
     },
     createCookieConsent: {
       description: "Record a user's cookie consent preferences",
@@ -80,19 +79,17 @@ export function createMedalTools(client: MedalSocialClient) {
         client.createCookieConsent(args),
     },
     createEventSignup: {
-      description: 'Create an event signup with contact and event details',
+      description: "Create an event signup with contact and event details",
       parameters: EventSignupSchema,
-      execute: async (args: z.infer<typeof EventSignupSchema>) =>
-        client.createEventSignup(args),
+      execute: async (args: z.infer<typeof EventSignupSchema>) => client.createEventSignup(args),
     },
     createNote: {
-      description: 'Create a free-form note for inbound messages',
+      description: "Create a free-form note for inbound messages",
       parameters: NoteSchema,
-      execute: async (args: z.infer<typeof NoteSchema>) =>
-        client.createNote(args),
+      execute: async (args: z.infer<typeof NoteSchema>) => client.createNote(args),
     },
     sendTransactionalEmail: {
-      description: 'Send a transactional email by template slug',
+      description: "Send a transactional email by template slug",
       parameters: TransactionalEmailSchema,
       execute: async (args: z.infer<typeof TransactionalEmailSchema>) =>
         client.sendTransactionalEmail(args),

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,31 @@
+[plugin]
+name = "medalsocial-sdk"
+version = "0.1.0"
+description = "Medal Social API client for Pilot crew"
+
+[permissions]
+network = ["api.medalsocial.com"]
+
+[[tools]]
+name = "create_lead"
+description = "Create one or more leads in Medal Social CRM"
+
+[[tools]]
+name = "create_contact_note"
+description = "Attach a note to a contact by ID"
+
+[[tools]]
+name = "create_cookie_consent"
+description = "Record a user's cookie consent preferences"
+
+[[tools]]
+name = "create_event_signup"
+description = "Create an event signup with contact and event details"
+
+[[tools]]
+name = "create_note"
+description = "Create a free-form note for inbound messages"
+
+[[tools]]
+name = "send_transactional_email"
+description = "Send a transactional email by template slug"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.8.3
@@ -1623,6 +1627,9 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -3077,5 +3084,7 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@1.2.1: {}
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,8 +228,11 @@ export class MedalSocialClient {
 }
 
 /** Convenience factory for Pilot/agent integration — instantiates client from a bearer token. */
-export function createMedalClient(apiKey: string, options?: Omit<ClientOptions, 'auth'>): MedalSocialClient {
-  return new MedalSocialClient({ ...options, auth: { kind: 'bearer', token: apiKey } });
+export function createMedalClient(
+  apiKey: string,
+  options?: Omit<ClientOptions, "auth">,
+): MedalSocialClient {
+  return new MedalSocialClient({ ...options, auth: { kind: "bearer", token: apiKey } });
 }
 
 export default MedalSocialClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,4 +227,9 @@ export class MedalSocialClient {
   }
 }
 
+/** Convenience factory for Pilot/agent integration — instantiates client from a bearer token. */
+export function createMedalClient(apiKey: string, options?: Omit<ClientOptions, 'auth'>): MedalSocialClient {
+  return new MedalSocialClient({ ...options, auth: { kind: 'bearer', token: apiKey } });
+}
+
 export default MedalSocialClient;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import MedalSocialClient from "../src";
+import MedalSocialClient, { createMedalClient } from "../src";
 
 describe("MedalSocialClient", () => {
   beforeEach(() => {
@@ -311,5 +311,19 @@ describe("misc coverage paths", () => {
     const res = await client.createNote({ name: "N", email: "n@example.com" });
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createMedalClient", () => {
+  it("returns a MedalSocialClient instance", () => {
+    const client = createMedalClient("test-api-key");
+    expect(client).toBeInstanceOf(MedalSocialClient);
+  });
+
+  it("uses bearer auth with the provided key", async () => {
+    const client = createMedalClient("my-key");
+    const auth = (client as unknown as { auth: { kind: string; token: string } }).auth;
+    expect(auth.kind).toBe("bearer");
+    expect(auth.token).toBe("my-key");
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.{test,spec}.ts"],
+    include: ["tests/**/*.{test,spec}.ts", "pilot/**/*.{test,spec}.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
Adds Pilot plugin manifest and createMedalTools factory so Pilot crew agents can call Medal APIs.

## Changes

- `src/index.ts`: add `createMedalClient(apiKey)` convenience factory for agent integration
- `plugin.toml`: Pilot plugin manifest declaring all 6 SDK tools and network permissions
- `pilot/index.ts`: `createMedalTools(client)` factory returning Vercel AI SDK `tool()`-compatible definitions with Zod schemas for all 6 methods
- `pilot/index.test.ts`: 4 tests covering tool shape and execution
- `package.json`: add `zod` dep, `./pilot` export entry point, `typecheck` script, updated build to compile pilot entry
- `vitest.config.ts`: extend test include to cover `pilot/` directory

## Follow-up

A separate Pilot-repo PR (after this publishes) will wire the SDK into Pilot's crew tool registry and add `MEDAL_API_KEY` to Pilot's config schema.