### PR TITLE
fix: add packageManager field for pnpm/action-setup in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "TypeScript SDK for Medal Social API — posts, emails, contacts, deals, and GDPR compliance",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.11.0",
   "author": "Medal Social / Ali Aljumaili",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds `"packageManager": "pnpm@10.11.0"` to package.json so `pnpm/action-setup` v5 can detect the pnpm version without requiring an explicit `version` input in the workflow.