### PR TITLE
fix: use changeset publish to skip already-published versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "biome check .",
     "prepublishOnly": "pnpm test && pnpm build",
     "version": "changeset version",
-    "release": "pnpm build && pnpm publish --access public --no-git-checks"
+    "release": "pnpm build && changeset publish"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Changes release script from `pnpm publish` to `changeset publish`. The changeset CLI checks the registry first and gracefully skips versions already on npm, instead of failing with E403.