### PR TITLE
feat: Pilot integration — createMedalClient + createMedalTools for v1 SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./pilot": {
+      "types": "./dist/pilot/index.d.ts",
+      "import": "./dist/pilot/index.mjs",
+      "require": "./dist/pilot/index.js"
     }
   },
   "sideEffects": false,
@@ -30,7 +35,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
-    "build": "tsup src/index.ts --dts --format esm,cjs --sourcemap",
+    "build": "tsup src/index.ts pilot/index.ts --dts --format esm,cjs --sourcemap",
     "dev": "tsup src/index.ts --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -71,6 +76,9 @@
     "posts",
     "social-media"
   ],
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@changesets/changelog-github": "^0.6.0",

--- a/pilot/index.test.ts
+++ b/pilot/index.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { Medal } from "../src/index.js";
+import { createMedalTools } from "./index.js";
+
+const mockClient = {
+  emails: {
+    send: vi.fn().mockResolvedValue({ data: { id: "email_1", status: "queued" } }),
+  },
+  contacts: {
+    create: vi.fn().mockResolvedValue({ data: { id: "contact_1" } }),
+    addNote: vi.fn().mockResolvedValue({ data: { id: "note_1" } }),
+  },
+  deals: {
+    create: vi.fn().mockResolvedValue({ data: { id: "deal_1" } }),
+  },
+  gdpr: {
+    recordConsent: vi.fn().mockResolvedValue({ data: { id: "consent_1" } }),
+    cookieConsent: vi.fn().mockResolvedValue({ success: true }),
+  },
+} as unknown as Medal;
+
+describe("createMedalTools", () => {
+  it("returns an object with all 6 tools", () => {
+    const tools = createMedalTools(mockClient);
+    expect(Object.keys(tools)).toHaveLength(6);
+    expect(tools).toHaveProperty("sendEmail");
+    expect(tools).toHaveProperty("createContact");
+    expect(tools).toHaveProperty("addContactNote");
+    expect(tools).toHaveProperty("recordCookieConsent");
+    expect(tools).toHaveProperty("recordConsent");
+    expect(tools).toHaveProperty("createDeal");
+  });
+
+  it("each tool has description, parameters (ZodSchema), and execute", () => {
+    const tools = createMedalTools(mockClient);
+    for (const [, tool] of Object.entries(tools)) {
+      expect(tool).toHaveProperty("description");
+      expect(typeof tool.description).toBe("string");
+      expect(tool).toHaveProperty("parameters");
+      expect(tool.parameters).toBeInstanceOf(z.ZodObject);
+      expect(tool).toHaveProperty("execute");
+      expect(typeof tool.execute).toBe("function");
+    }
+  });
+
+  it("sendEmail calls client.emails.send", async () => {
+    const tools = createMedalTools(mockClient);
+    await tools.sendEmail.execute({ template_slug: "welcome", to: "a@b.com" });
+    expect(mockClient.emails.send).toHaveBeenCalledWith({
+      template_slug: "welcome",
+      to: "a@b.com",
+    });
+  });
+
+  it("createContact calls client.contacts.create", async () => {
+    const tools = createMedalTools(mockClient);
+    await tools.createContact.execute({ email: "alice@example.com", first_name: "Alice" });
+    expect(mockClient.contacts.create).toHaveBeenCalledWith({
+      email: "alice@example.com",
+      first_name: "Alice",
+    });
+  });
+
+  it("addContactNote calls client.contacts.addNote with split args", async () => {
+    const tools = createMedalTools(mockClient);
+    await tools.addContactNote.execute({ contactId: "c_123", content: "Followed up" });
+    expect(mockClient.contacts.addNote).toHaveBeenCalledWith("c_123", { content: "Followed up" });
+  });
+
+  it("createDeal calls client.deals.create", async () => {
+    const tools = createMedalTools(mockClient);
+    await tools.createDeal.execute({ title: "Acme Partnership", value: 50000 });
+    expect(mockClient.deals.create).toHaveBeenCalledWith({
+      title: "Acme Partnership",
+      value: 50000,
+    });
+  });
+});

--- a/pilot/index.ts
+++ b/pilot/index.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import type { Medal } from "../src/index.js";
+
+const SendEmailSchema = z.object({
+  template_slug: z.string(),
+  to: z.string().email(),
+  name: z.string().optional(),
+  locale: z.string().optional(),
+  variables: z.record(z.string()).optional(),
+});
+
+const CreateContactSchema = z.object({
+  email: z.string().email(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  phone: z.string().optional(),
+  company: z.string().optional(),
+  job_title: z.string().optional(),
+  status: z.enum(["lead", "prospect", "customer", "churned", "archived"]).optional(),
+  notes: z.string().optional(),
+});
+
+const AddContactNoteSchema = z.object({
+  contactId: z.string(),
+  content: z.string(),
+});
+
+const CookieConsentSchema = z.object({
+  domain: z.string(),
+  consentStatus: z.enum(["granted", "denied", "partial"]),
+  consentTimestamp: z.string(),
+  ipAddress: z.string().optional(),
+  userAgent: z.string().optional(),
+  cookiePreferences: z.object({
+    necessary: z.object({ allowed: z.boolean() }).optional(),
+    analytics: z.object({ allowed: z.boolean() }).optional(),
+    marketing: z.object({ allowed: z.boolean() }).optional(),
+    functional: z.object({ allowed: z.boolean() }).optional(),
+  }),
+});
+
+const RecordConsentSchema = z.object({
+  email: z.string().email(),
+  consent_type: z.enum(["marketing_email", "analytics_tracking", "third_party_sharing"]),
+  granted: z.boolean(),
+  source: z.string().optional(),
+  ip_address: z.string().optional(),
+});
+
+const CreateDealSchema = z.object({
+  title: z.string(),
+  description: z.string().optional(),
+  value: z.number().optional(),
+  currency: z.string().optional(),
+  contact_email: z.string().email().optional(),
+  notes: z.string().optional(),
+});
+
+export function createMedalTools(client: Medal) {
+  return {
+    sendEmail: {
+      description: "Send a transactional email using a template",
+      parameters: SendEmailSchema,
+      execute: async (args: z.infer<typeof SendEmailSchema>) => client.emails.send(args),
+    },
+    createContact: {
+      description: "Create a new contact in Medal Social CRM",
+      parameters: CreateContactSchema,
+      execute: async (args: z.infer<typeof CreateContactSchema>) => client.contacts.create(args),
+    },
+    addContactNote: {
+      description: "Add a note to a contact's timeline",
+      parameters: AddContactNoteSchema,
+      execute: async (args: z.infer<typeof AddContactNoteSchema>) =>
+        client.contacts.addNote(args.contactId, { content: args.content }),
+    },
+    recordCookieConsent: {
+      description: "Record a user's cookie consent preferences",
+      parameters: CookieConsentSchema,
+      execute: async (args: z.infer<typeof CookieConsentSchema>) => client.gdpr.cookieConsent(args),
+    },
+    recordConsent: {
+      description: "Record a GDPR consent decision for a contact by email",
+      parameters: RecordConsentSchema,
+      execute: async (args: z.infer<typeof RecordConsentSchema>) => client.gdpr.recordConsent(args),
+    },
+    createDeal: {
+      description: "Create a new deal in Medal Social CRM",
+      parameters: CreateDealSchema,
+      execute: async (args: z.infer<typeof CreateDealSchema>) => client.deals.create(args),
+    },
+  };
+}

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,31 @@
+[plugin]
+name = "medalsocial-sdk"
+version = "1.0.0"
+description = "Medal Social API client for Pilot crew"
+
+[permissions]
+network = ["api.medalsocial.com"]
+
+[[tools]]
+name = "send_email"
+description = "Send a transactional email using a template"
+
+[[tools]]
+name = "create_contact"
+description = "Create a new contact in Medal Social CRM"
+
+[[tools]]
+name = "add_contact_note"
+description = "Add a note to a contact's timeline"
+
+[[tools]]
+name = "record_cookie_consent"
+description = "Record a user's cookie consent preferences"
+
+[[tools]]
+name = "record_consent"
+description = "Record a GDPR consent decision for a contact by email"
+
+[[tools]]
+name = "create_deal"
+description = "Create a new deal in Medal Social CRM"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.8.3
@@ -2532,6 +2536,9 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -4960,6 +4967,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,4 +171,8 @@ export { Posts } from "./resources/posts";
 export { Workspaces } from "./resources/workspaces";
 export { BaseClient } from "./client";
 
+export function createMedalClient(apiKey: string, options?: MedalOptions): Medal {
+  return new Medal(apiKey, options);
+}
+
 export default Medal;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.{test,spec}.ts"],
+    include: ["tests/**/*.{test,spec}.ts", "pilot/**/*.{test,spec}.ts"],
     exclude: ["tests/integration.test.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Adds Pilot crew integration for the v1 Medal SDK.

## Changes

- `src/index.ts`: exports `createMedalClient(apiKey, options?)` factory — wraps `new Medal()` for agent/Pilot use
- `plugin.toml`: Pilot plugin manifest with 6 tools and network permissions
- `pilot/index.ts`: `createMedalTools(client: Medal)` factory with Zod-typed tool definitions for sendEmail, createContact, addContactNote, recordCookieConsent, recordConsent, createDeal
- `pilot/index.test.ts`: 6 tests covering tool shape and execution
- `package.json`: zod runtime dep, `./pilot` export entry point, updated build to compile pilot entry
- `vitest.config.ts`: extend test include to cover `pilot/` directory

## Test results

All 64 tests pass (6 new pilot tests + 58 existing client tests).

## Follow-up

A separate Pilot-repo PR will wire the SDK into Pilot's crew tool registry and add `MEDAL_API_KEY` to Pilot's config schema.