### PR TITLE
fix: sync changeset workspace fix to prod

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
+  - "."
   - "examples/*"
 


### PR DESCRIPTION
Syncs the `pnpm-workspace.yaml` fix to prod. This unblocks the release workflow — changesets was failing to resolve `@medalsocial/sdk` because the root package was not in the pnpm workspace.