### PR TITLE
release: sync dev to prod — repo URL fix + knip config

### DIFF
--- a/.changeset/patch-fix-repo-metadata-urls.md
+++ b/.changeset/patch-fix-repo-metadata-urls.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/sdk": patch
+---
+
+Fix repository metadata URLs in package.json to point to the correct MedalSocial-SDK repository. Updates repository.url, bugs.url, and homepage fields for npm provenance compliance.

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,6 @@
     "@commitlint/cli",
     "secretlint"
   ],
-  "ignore": ["src/index.ts"],
+  "ignore": ["src/index.ts", "src/devices/**", "vitest.integration.config.ts"],
   "ignoreExportsUsedInFile": true
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "author": "Medal Social / Ali Aljumaili",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Medal-Social/MedalSocial.git"
+    "url": "git+https://github.com/Medal-Social/MedalSocial-SDK.git"
   },
   "bugs": {
-    "url": "https://github.com/Medal-Social/MedalSocial/issues"
+    "url": "https://github.com/Medal-Social/MedalSocial-SDK/issues"
   },
-  "homepage": "https://github.com/Medal-Social/MedalSocial#readme",
+  "homepage": "https://github.com/Medal-Social/MedalSocial-SDK#readme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Fixes `repository.url` in `package.json` to match current repo name (`MedalSocial-SDK`) — unblocks npm OIDC provenance on publish
- Adds `knip.json` ignore entries for `src/devices/**` and `vitest.integration.config.ts` — fixes CI security job

This should be the last blocker before `@medalsocial/sdk@1.1.0` publishes successfully.