### PR TITLE
release: sync dev to prod — jsr.json version fix

### DIFF
--- a/.changeset/patch-fix-repo-metadata-urls.md
+++ b/.changeset/patch-fix-repo-metadata-urls.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/sdk": patch
+---
+
+Fix repository metadata URLs in package.json to point to the correct MedalSocial-SDK repository. Updates repository.url, bugs.url, and homepage fields for npm provenance compliance.

--- a/jsr.json
+++ b/jsr.json
@@ -1,4 +1,5 @@
 {
   "name": "@medalsocial/sdk",
+  "version": "1.1.1",
   "exports": "./src/index.ts"
 }

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,6 @@
     "@commitlint/cli",
     "secretlint"
   ],
-  "ignore": ["src/index.ts"],
+  "ignore": ["src/index.ts", "src/devices/**", "vitest.integration.config.ts"],
   "ignoreExportsUsedInFile": true
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "author": "Medal Social / Ali Aljumaili",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Medal-Social/MedalSocial.git"
+    "url": "git+https://github.com/Medal-Social/MedalSocial-SDK.git"
   },
   "bugs": {
-    "url": "https://github.com/Medal-Social/MedalSocial/issues"
+    "url": "https://github.com/Medal-Social/MedalSocial-SDK/issues"
   },
-  "homepage": "https://github.com/Medal-Social/MedalSocial#readme",
+  "homepage": "https://github.com/Medal-Social/MedalSocial-SDK#readme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "quality": "pnpm lint && pnpm test",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm test && pnpm build",
-    "version": "changeset version",
+    "version": "changeset version && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('./package.json','utf8'));const j=JSON.parse(fs.readFileSync('./jsr.json','utf8'));j.version=p.version;fs.writeFileSync('./jsr.json',JSON.stringify(j,null,2)+'\\n')\"",
     "release": "pnpm build && changeset publish && pnpm exec jsr publish",
     "changeset": "changeset",
     "knip:report": "knip --reporter json --no-exit-code",


### PR DESCRIPTION
Syncs the jsr.json version field fix to prod. The release workflow will skip npm (1.1.1 already published) and publish @medalsocial/sdk@1.1.1 to JSR.