### PR TITLE
docs: JSDoc + JSR score 100% improvements

### DIFF
--- a/.changeset/patch-jsdoc-jsr-score.md
+++ b/.changeset/patch-jsdoc-jsr-score.md
@@ -1,0 +1,10 @@
+---
+"@medalsocial/sdk": patch
+---
+
+Add JSDoc documentation to all exported symbols for JSR 100% score. This includes:
+- `@module` JSDoc to `src/index.ts` entrypoint
+- JSDoc for every exported type, interface, and class across all type and resource files
+- JSDoc for `MedalOptions`, `createMedalClient`, `ClientConfig`, and all `BaseClient` public methods
+- Added `description` field to `jsr.json`
+- Added `.github/workflows/jsr-publish.yml` for JSR provenance publishing

--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -1,0 +1,31 @@
+name: Publish to JSR
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish to JSR
+        run: npx jsr publish

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,6 @@
 {
   "name": "@medalsocial/sdk",
   "version": "1.1.3",
+  "description": "Official TypeScript SDK for the Medal Social API — posts, emails, contacts, deals, GDPR, and workspaces.",
   "exports": "./src/index.ts"
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { MedalApiError } from "./types/common";
 
+/** Configuration for the low-level HTTP client. */
 export interface ClientConfig {
   baseUrl: string;
   token: string;
@@ -13,17 +14,20 @@ export interface ClientConfig {
  * Handles authentication, retries, timeout, and error parsing.
  */
 export class BaseClient {
+  /** Resolved client configuration. */
   readonly config: ClientConfig;
 
   constructor(config: ClientConfig) {
     this.config = config;
   }
 
+  /** Execute an authenticated GET request and return the parsed JSON body. */
   async get<T>(path: string, params?: Record<string, string | undefined>): Promise<T> {
     const url = this.buildUrl(path, params);
     return this.request<T>(url, { method: "GET" });
   }
 
+  /** Execute an authenticated POST request with a JSON body. */
   async post<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>(this.buildUrl(path), {
       method: "POST",
@@ -32,6 +36,7 @@ export class BaseClient {
     });
   }
 
+  /** Execute an authenticated PATCH request with a JSON body. */
   async patch<T>(path: string, body: unknown): Promise<T> {
     return this.request<T>(this.buildUrl(path), {
       method: "PATCH",
@@ -40,6 +45,7 @@ export class BaseClient {
     });
   }
 
+  /** Execute an authenticated DELETE request. */
   async delete<T>(path: string): Promise<T> {
     return this.request<T>(this.buildUrl(path), { method: "DELETE" });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,23 @@
+/**
+ * Official TypeScript SDK for the Medal Social API.
+ *
+ * Provides typed access to posts, emails, contacts, deals, GDPR compliance,
+ * and workspace management. Works in Node.js, Deno, Bun, Cloudflare Workers,
+ * and modern browsers.
+ *
+ * @example
+ * ```ts
+ * import { Medal } from "@medalsocial/sdk";
+ *
+ * const medal = new Medal("medal_xxx");
+ * const { data: post } = await medal.posts.create({
+ *   content: "Hello world!",
+ *   channel_ids: ["ch_1"],
+ * });
+ * ```
+ *
+ * @module
+ */
 import { BaseClient } from "./client";
 import { Contacts } from "./resources/contacts";
 import { Deals } from "./resources/deals";
@@ -6,8 +26,9 @@ import { Gdpr } from "./resources/gdpr";
 import { Posts } from "./resources/posts";
 import { Workspaces } from "./resources/workspaces";
 
+/** Options for configuring the {@link Medal} client. */
 export interface MedalOptions {
-  /** Override the base URL (defaults to https://api.medalsocial.com). */
+  /** Override the base URL (defaults to https://io.medalsocial.com). */
   baseUrl?: string;
   /** Request timeout in ms (default 30000). */
   timeout?: number;
@@ -171,6 +192,7 @@ export { Posts } from "./resources/posts";
 export { Workspaces } from "./resources/workspaces";
 export { BaseClient } from "./client";
 
+/** Convenience factory — equivalent to `new Medal(apiKey, options)`. */
 export function createMedalClient(apiKey: string, options?: MedalOptions): Medal {
   return new Medal(apiKey, options);
 }

--- a/src/resources/contacts.ts
+++ b/src/resources/contacts.ts
@@ -15,6 +15,7 @@ import type {
   UpdateContactInput,
 } from "../types/contacts";
 
+/** Manage contacts in the workspace CRM. */
 export class Contacts {
   constructor(private client: BaseClient) {}
 

--- a/src/resources/deals.ts
+++ b/src/resources/deals.ts
@@ -10,6 +10,7 @@ import type {
   UpdateDealInput,
 } from "../types/deals";
 
+/** Manage sponsorship deals in the workspace. */
 export class Deals {
   constructor(private client: BaseClient) {}
 

--- a/src/resources/emails.ts
+++ b/src/resources/emails.ts
@@ -11,6 +11,7 @@ import type {
   SendEmailInput,
 } from "../types/emails";
 
+/** Manage email templates stored in the workspace. */
 class EmailTemplates {
   constructor(private client: BaseClient) {}
 
@@ -28,6 +29,7 @@ class EmailTemplates {
   }
 }
 
+/** Send transactional emails and manage templates. */
 export class Emails {
   readonly templates: EmailTemplates;
 

--- a/src/resources/gdpr.ts
+++ b/src/resources/gdpr.ts
@@ -8,6 +8,7 @@ import type {
   RecordConsentInput,
 } from "../types/gdpr";
 
+/** Manage GDPR compliance — data exports, consent records, and cookie consent. */
 export class Gdpr {
   constructor(private client: BaseClient) {}
 

--- a/src/resources/posts.ts
+++ b/src/resources/posts.ts
@@ -12,6 +12,7 @@ import type {
   UpdatePostInput,
 } from "../types/posts";
 
+/** Create and publish posts across connected channels. */
 export class Posts {
   constructor(private client: BaseClient) {}
 

--- a/src/resources/workspaces.ts
+++ b/src/resources/workspaces.ts
@@ -2,6 +2,7 @@ import type { BaseClient } from "../client";
 import type { ApiResponse } from "../types/common";
 import type { Workspace } from "../types/workspaces";
 
+/** Access workspaces for the authenticated credential. */
 export class Workspaces {
   constructor(private client: BaseClient) {}
 

--- a/src/types/contacts.ts
+++ b/src/types/contacts.ts
@@ -1,5 +1,6 @@
 import type { PaginationOptions } from "./common";
 
+/** A contact in the workspace CRM. */
 export interface Contact {
   id: string;
   email: string;
@@ -18,25 +19,33 @@ export interface Contact {
   updated_at: string | null;
 }
 
+/** Result returned after creating a contact. */
 export interface ContactCreateResult {
   id: string;
 }
 
+/** Result returned after updating a contact. */
 export interface ContactUpdateResult {
   success: true;
 }
 
+/** Result returned after deleting a contact. */
 export interface ContactRemoveResult {
   success: true;
 }
 
+/** Result returned after adding a note to a contact. */
 export interface ContactNoteResult {
   id: string;
 }
 
+/** Lifecycle stage of a contact in the CRM. */
 export type ContactStatus = "lead" | "prospect" | "customer" | "churned" | "archived";
+
+/** Email deliverability status for a contact. */
 export type EmailStatus = "subscribed" | "unsubscribed" | "bounced" | "complained";
 
+/** Input for creating a new contact. */
 export interface CreateContactInput {
   email: string;
   first_name?: string;
@@ -59,6 +68,7 @@ export interface CreateContactInput {
       };
 }
 
+/** Input for updating one or more fields on a contact. */
 export interface UpdateContactInput {
   email?: string;
   first_name?: string;
@@ -74,6 +84,7 @@ export interface UpdateContactInput {
   custom_fields?: Record<string, unknown>;
 }
 
+/** Options for listing contacts with pagination and filters. */
 export interface ListContactsOptions extends PaginationOptions {
   status?: ContactStatus;
   email_status?: EmailStatus;
@@ -81,6 +92,7 @@ export interface ListContactsOptions extends PaginationOptions {
   search?: string;
 }
 
+/** A single contact record for bulk import. */
 export interface ImportContactInput {
   email: string;
   first_name?: string;
@@ -92,12 +104,14 @@ export interface ImportContactInput {
   status?: string;
 }
 
+/** Summary returned after a bulk contact import. */
 export interface ImportContactsResult {
   added: number;
   skipped: number;
   total: number;
 }
 
+/** A contact activity event on the timeline. */
 export interface Activity {
   id: string;
   type: string;
@@ -109,6 +123,7 @@ export interface Activity {
   created_at: string | null;
 }
 
+/** Input for adding a text note to a contact's timeline. */
 export interface AddNoteInput {
   content: string;
 }

--- a/src/types/deals.ts
+++ b/src/types/deals.ts
@@ -1,5 +1,6 @@
 import type { PaginationOptions } from "./common";
 
+/** A sponsorship or brand deal in the workspace. */
 export interface Deal {
   id: string;
   title: string;
@@ -19,18 +20,22 @@ export interface Deal {
   updated_at: string | null;
 }
 
+/** Result returned after creating a deal. */
 export interface DealCreateResult {
   id: string;
 }
 
+/** Result returned after updating a deal. */
 export interface DealUpdateResult {
   success: true;
 }
 
+/** Result returned after deleting a deal. */
 export interface DealRemoveResult {
   success: true;
 }
 
+/** Lifecycle stage of a sponsorship deal. */
 export type DealStatus =
   | "draft"
   | "open"
@@ -41,6 +46,7 @@ export type DealStatus =
   | "on_hold"
   | "churned";
 
+/** Input for creating a new deal. */
 export interface CreateDealInput {
   title: string;
   description?: string;
@@ -56,6 +62,7 @@ export interface CreateDealInput {
   notes?: string;
 }
 
+/** Input for updating one or more fields on a deal. */
 export interface UpdateDealInput {
   title?: string;
   description?: string;
@@ -72,6 +79,7 @@ export interface UpdateDealInput {
   notes?: string;
 }
 
+/** Options for listing deals with pagination and filters. */
 export interface ListDealsOptions extends PaginationOptions {
   status?: DealStatus;
   search?: string;

--- a/src/types/emails.ts
+++ b/src/types/emails.ts
@@ -1,3 +1,4 @@
+/** Input for sending a transactional email via a template. */
 export interface SendEmailInput {
   template_slug: string;
   to: string;
@@ -8,11 +9,13 @@ export interface SendEmailInput {
   contact_id?: string;
 }
 
+/** Result returned after queuing a transactional email send (HTTP 202). */
 export interface EmailSendResult {
   id: string;
   status: string;
 }
 
+/** Full record for a sent email, including delivery timestamps. */
 export interface EmailSend {
   id: string;
   status: string;
@@ -29,6 +32,7 @@ export interface EmailSend {
   error_message: string | null;
 }
 
+/** Input for sending the same template to multiple recipients (max 100). */
 export interface BatchSendInput {
   template_slug: string;
   default_locale?: string;
@@ -40,6 +44,7 @@ export interface BatchSendInput {
   }[];
 }
 
+/** Summary returned after queuing a batch email send. */
 export interface BatchSendSummary {
   batch_id: string;
   total: number;
@@ -50,6 +55,7 @@ export interface BatchSendSummary {
 /** @deprecated Use `BatchSendSummary` for `emails.batch()` responses. */
 export type BatchSendResult = BatchSendSummary;
 
+/** An email template stored in the workspace. */
 export interface EmailTemplate {
   id: string;
   name: string;
@@ -68,6 +74,7 @@ export interface EmailTemplate {
   updated_at: string | null;
 }
 
+/** Full template detail including per-locale content. */
 export interface EmailTemplateDetail extends EmailTemplate {
   html_content: string | null;
   text_content: string | null;
@@ -87,6 +94,7 @@ export interface EmailTemplateDetail extends EmailTemplate {
   }[];
 }
 
+/** Options for fetching a template with locale resolution. */
 export interface GetTemplateOptions {
   locale?: string;
   fallback_locale?: string;

--- a/src/types/gdpr.ts
+++ b/src/types/gdpr.ts
@@ -1,3 +1,4 @@
+/** A workspace data export request and its current status. */
 export interface GdprExport {
   id: string;
   request_type: string;
@@ -9,8 +10,10 @@ export interface GdprExport {
   expires_at?: string | null;
 }
 
+/** GDPR consent category. */
 export type ConsentType = "marketing_email" | "analytics_tracking" | "third_party_sharing";
 
+/** Input for recording a GDPR consent decision for a contact. */
 export interface RecordConsentInput {
   email: string;
   consent_type: ConsentType;
@@ -21,6 +24,7 @@ export interface RecordConsentInput {
   version?: string;
 }
 
+/** A stored consent record for a contact. */
 export interface ConsentRecord {
   id: string;
   email: string;
@@ -32,6 +36,7 @@ export interface ConsentRecord {
   version?: string;
 }
 
+/** Result returned after recording a consent decision. */
 export interface ConsentResult {
   id: string;
 }
@@ -39,6 +44,7 @@ export interface ConsentResult {
 /** @deprecated Use `ConsentRecord[]` for `gdpr.getConsent()` responses. */
 export type ContactConsents = ConsentRecord[];
 
+/** Input for recording cookie consent from an external site. */
 export interface CookieConsentInput {
   domain: string;
   consentStatus: "granted" | "denied" | "partial" | string;
@@ -54,6 +60,7 @@ export interface CookieConsentInput {
   };
 }
 
+/** Consent decision and optional cookie records for a single cookie category. */
 export interface CookieCategoryConsent {
   allowed: boolean;
   cookieRecords?: {

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -1,5 +1,6 @@
 import type { PaginationOptions } from "./common";
 
+/** A post in the workspace (list view). */
 export interface Post {
   id: string;
   type: PostType;
@@ -16,8 +17,10 @@ export interface Post {
   updated_at: string | null;
 }
 
+/** Content format / distribution channel type for a post. */
 export type PostType = "social" | "newsletter" | "blog";
 
+/** Per-channel variant of a post with publishing state. */
 export interface PostVariant {
   id: string;
   channel_id: string;
@@ -32,10 +35,12 @@ export interface PostVariant {
   error: string | null;
 }
 
+/** Full post detail including per-channel variants. */
 export interface PostDetail extends Post {
   variants: PostVariant[];
 }
 
+/** A connected publishing channel in the workspace. */
 export interface Channel {
   id: string;
   platform: string | null;
@@ -45,6 +50,7 @@ export interface Channel {
   connected_at: string | null;
 }
 
+/** Input for creating a new post. */
 export interface CreatePostInput {
   type?: PostType;
   title?: string;
@@ -52,26 +58,31 @@ export interface CreatePostInput {
   channel_ids: string[];
 }
 
+/** Input for updating a draft post's title or content. */
 export interface UpdatePostInput {
   title?: string;
   content?: string;
 }
 
+/** Input for scheduling a post for future publication. */
 export interface SchedulePostInput {
   /** Unix timestamp (ms) or ISO datetime string. */
   scheduled_at: number | string;
 }
 
+/** Options for listing posts with pagination and filters. */
 export interface ListPostsOptions extends PaginationOptions {
   status?: string;
   type?: PostType;
 }
 
+/** Result returned after scheduling a post. */
 export interface ScheduleResult {
   success: boolean;
   workflow_id: string;
 }
 
+/** Result returned after publishing a post immediately. */
 export interface PublishResult {
   success: boolean;
   workflow_id: string;

--- a/src/types/workspaces.ts
+++ b/src/types/workspaces.ts
@@ -1,3 +1,4 @@
+/** A Medal Social workspace accessible to the authenticated credential. */
 export interface Workspace {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

- JSDoc on all exported symbols (~50 previously undocumented)
- `@module` doc on `src/index.ts` entrypoint (required for JSR module doc score)
- `description` added to `jsr.json` for JSR discoverability
- GitHub Actions workflow for JSR provenance publishing via OIDC
- Fix: corrected `baseUrl` default in `MedalOptions` JSDoc (`io.medalsocial.com`, not `api.medalsocial.com`)

## Test Plan
- [x] All 64 tests pass
- [x] `tsc --noEmit` clean
- [x] Biome lint clean