### PR TITLE
feat: add ai.generate() for workspace LLM text generation

### DIFF
--- a/.changeset/ai-generate.md
+++ b/.changeset/ai-generate.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/sdk": minor
+---
+
+Add `medal.ai.generate()` for workspace LLM text generation via `POST /api/v1/ai/generate`. Backed by the workspace's configured model (OpenRouter, default `anthropic/claude-sonnet-4`) with optional brand context, skills, `{{placeholder}}` variables, temperature and max-token controls. Usage is metered against the workspace AI budget.

--- a/openapi/medal-social.openapi.yaml
+++ b/openapi/medal-social.openapi.yaml
@@ -17,6 +17,8 @@ tags:
     description: Create, schedule, publish, and inspect posts.
   - name: Emails
     description: Send transactional email and inspect templates.
+  - name: AI
+    description: Generate text with the workspace's configured LLM.
   - name: Contacts
     description: Manage workspace CRM contacts.
   - name: Deals
@@ -263,6 +265,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse_EmailSend"
+        default:
+          $ref: "#/components/responses/ApiError"
+  /api/v1/ai/generate:
+    post:
+      tags: [AI]
+      operationId: generateText
+      summary: Generate text with the workspace's configured LLM
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GenerateTextInput"
+      responses:
+        "200":
+          description: Generated text.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse_GenerateTextResult"
         default:
           $ref: "#/components/responses/ApiError"
   /api/v1/contacts:
@@ -881,6 +903,51 @@ components:
           type: boolean
         workflow_id:
           type: string
+    GenerateTextInput:
+      type: object
+      required: [prompt]
+      properties:
+        prompt:
+          type: string
+          description: Prompt to send to the model. Supports {{placeholder}} substitution when variables is provided.
+        model:
+          type: string
+          description: Model id in provider/model form. Defaults to the workspace's selected model.
+        system_prompt:
+          type: string
+          description: Override the system prompt. When omitted, the workspace brand context is used.
+        temperature:
+          type: number
+          minimum: 0
+          maximum: 2
+        max_tokens:
+          type: integer
+          minimum: 32
+          maximum: 4096
+        use_brand_context:
+          type: boolean
+        use_skills:
+          type: boolean
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+    GenerateTextResult:
+      type: object
+      required: [text, model, usage]
+      properties:
+        text:
+          type: string
+        model:
+          type: string
+        usage:
+          type: object
+          required: [input_tokens, output_tokens]
+          properties:
+            input_tokens:
+              type: integer
+            output_tokens:
+              type: integer
     SendEmailInput:
       type: object
       required: [template_slug, to]
@@ -1654,6 +1721,8 @@ components:
       $ref: "#/components/schemas/Envelope_PublishResult"
     ApiResponse_ChannelArray:
       $ref: "#/components/schemas/Envelope_ChannelArray"
+    ApiResponse_GenerateTextResult:
+      $ref: "#/components/schemas/Envelope_GenerateTextResult"
     ApiResponse_EmailSendResult:
       $ref: "#/components/schemas/Envelope_EmailSendResult"
     ApiResponse_EmailSend:
@@ -1774,6 +1843,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Channel"
+    Envelope_GenerateTextResult:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/GenerateTextResult"
     Envelope_EmailSendResult:
       type: object
       required: [data]

--- a/scripts/assert-openapi-sdk-coverage.mjs
+++ b/scripts/assert-openapi-sdk-coverage.mjs
@@ -242,6 +242,14 @@ const expected = [
     "get",
     "/api/v1/me/workspaces",
   ],
+  [
+    "post",
+    "/api/v1/ai/generate",
+    "generateText",
+    "src/resources/ai.ts",
+    "post",
+    "/api/v1/ai/generate",
+  ],
 ];
 
 const errors = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@
  * @module
  */
 import { BaseClient } from "./client";
+import { AI } from "./resources/ai";
 import { Contacts } from "./resources/contacts";
 import { Deals } from "./resources/deals";
 import { Emails } from "./resources/emails";
@@ -87,6 +88,7 @@ export interface MedalOptions {
  * ```
  */
 export class Medal {
+  readonly ai: AI;
   readonly emails: Emails;
   readonly contacts: Contacts;
   readonly deals: Deals;
@@ -109,6 +111,7 @@ export class Medal {
       userAgent: "medalsocial-sdk/1.0.0 (+https://github.com/Medal-Social/MedalSocial)",
     });
 
+    this.ai = new AI(client);
     this.emails = new Emails(client);
     this.contacts = new Contacts(client);
     this.deals = new Deals(client);
@@ -121,6 +124,7 @@ export class Medal {
 // Re-export all types
 export { MedalApiError } from "./types/common";
 export type { ApiResponse, PaginatedResponse, PaginationOptions } from "./types/common";
+export type { GenerateTextInput, GenerateTextResult } from "./types/ai";
 export type {
   SendEmailInput,
   EmailSendResult,
@@ -189,6 +193,7 @@ export type {
 } from "./openapi.generated";
 
 // Resource class re-exports (for advanced usage)
+export { AI } from "./resources/ai";
 export { Emails } from "./resources/emails";
 export { Contacts } from "./resources/contacts";
 export { Deals } from "./resources/deals";

--- a/src/openapi.generated.ts
+++ b/src/openapi.generated.ts
@@ -187,6 +187,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/ai/generate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Generate text with the workspace's configured LLM */
+    post: operations["generateText"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/contacts": {
     parameters: {
       query?: never;
@@ -533,6 +550,29 @@ export interface components {
     PublishResult: {
       success: boolean;
       workflow_id: string;
+    };
+    GenerateTextInput: {
+      /** @description Prompt to send to the model. Supports {{placeholder}} substitution when variables is provided. */
+      prompt: string;
+      /** @description Model id in provider/model form. Defaults to the workspace's selected model. */
+      model?: string;
+      /** @description Override the system prompt. When omitted, the workspace brand context is used. */
+      system_prompt?: string;
+      temperature?: number;
+      max_tokens?: number;
+      use_brand_context?: boolean;
+      use_skills?: boolean;
+      variables?: {
+        [key: string]: string;
+      };
+    };
+    GenerateTextResult: {
+      text: string;
+      model: string;
+      usage: {
+        input_tokens: number;
+        output_tokens: number;
+      };
     };
     SendEmailInput: {
       template_slug: string;
@@ -912,6 +952,7 @@ export interface components {
     ApiResponse_ScheduleResult: components["schemas"]["Envelope_ScheduleResult"];
     ApiResponse_PublishResult: components["schemas"]["Envelope_PublishResult"];
     ApiResponse_ChannelArray: components["schemas"]["Envelope_ChannelArray"];
+    ApiResponse_GenerateTextResult: components["schemas"]["Envelope_GenerateTextResult"];
     ApiResponse_EmailSendResult: components["schemas"]["Envelope_EmailSendResult"];
     ApiResponse_EmailSend: components["schemas"]["Envelope_EmailSend"];
     ApiResponse_BatchSendSummary: components["schemas"]["Envelope_BatchSendSummary"];
@@ -966,6 +1007,9 @@ export interface components {
     };
     Envelope_ChannelArray: {
       data: components["schemas"]["Channel"][];
+    };
+    Envelope_GenerateTextResult: {
+      data: components["schemas"]["GenerateTextResult"];
     };
     Envelope_EmailSendResult: {
       data: components["schemas"]["EmailSendResult"];
@@ -1364,6 +1408,31 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ApiResponse_EmailSend"];
+        };
+      };
+      default: components["responses"]["ApiError"];
+    };
+  };
+  generateText: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["GenerateTextInput"];
+      };
+    };
+    responses: {
+      /** @description Generated text. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ApiResponse_GenerateTextResult"];
         };
       };
       default: components["responses"]["ApiError"];

--- a/src/resources/ai.ts
+++ b/src/resources/ai.ts
@@ -1,0 +1,29 @@
+import type { BaseClient } from "../client";
+import type { GenerateTextInput, GenerateTextResult } from "../types/ai";
+import type { ApiResponse } from "../types/common";
+
+/** Generate text with the workspace's configured LLM. */
+export class AI {
+  constructor(private client: BaseClient) {}
+
+  /**
+   * Generate text from a prompt using the workspace's configured model
+   * (OpenRouter-backed, default `anthropic/claude-sonnet-4`). The workspace
+   * brand context and skills are applied as the system prompt unless disabled,
+   * and usage is metered against the workspace AI budget.
+   *
+   * @example
+   * ```ts
+   * const { data } = await medal.ai.generate({
+   *   prompt: "Write a 3-bullet market summary.",
+   *   system_prompt: "You are a precise market analyst.",
+   *   max_tokens: 400,
+   *   use_brand_context: false,
+   * });
+   * console.log(data.text, data.model, data.usage.output_tokens);
+   * ```
+   */
+  async generate(input: GenerateTextInput): Promise<ApiResponse<GenerateTextResult>> {
+    return this.client.post("/api/v1/ai/generate", input);
+  }
+}

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,44 @@
+/** Input for generating text with the workspace's configured LLM. */
+export interface GenerateTextInput {
+  /**
+   * The prompt to send to the model. Supports `{{placeholder}}` substitution
+   * when `variables` is provided; otherwise it is sent verbatim.
+   */
+  prompt: string;
+  /**
+   * Model id in `provider/model` form (e.g. `anthropic/claude-sonnet-4`).
+   * Defaults to the workspace's selected model.
+   */
+  model?: string;
+  /**
+   * Override the system prompt. When omitted, the workspace brand context is
+   * used as the system prompt (unless `use_brand_context` is `false`).
+   */
+  system_prompt?: string;
+  /** Sampling temperature, 0–2. Defaults to the workspace setting. */
+  temperature?: number;
+  /** Maximum number of tokens to generate (32–4096). */
+  max_tokens?: number;
+  /**
+   * Prepend the workspace brand document, guidelines and skills as system
+   * context. Defaults to `true`. Ignored when `system_prompt` is set.
+   */
+  use_brand_context?: boolean;
+  /** Include workspace skills in the brand context. Defaults to `true`. */
+  use_skills?: boolean;
+  /** Values substituted into `{{placeholder}}` tokens in the prompt. */
+  variables?: Record<string, string>;
+}
+
+/** Result of a text generation request. */
+export interface GenerateTextResult {
+  /** The generated text. */
+  text: string;
+  /** The model that produced the text (`provider/model`). */
+  model: string;
+  /** Token usage for the request. */
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}


### PR DESCRIPTION
## Summary

Adds a new `ai` resource exposing **`medal.ai.generate({ prompt, ... })`**, mapping to `POST /api/v1/ai/generate`. Backed by the workspace's configured model (OpenRouter, default `anthropic/claude-sonnet-4`) with optional brand context, skills, `{{placeholder}}` variables, temperature and max-token controls; usage is metered against the workspace AI budget.

Pairs with the Convex API endpoint in `medal-monorepo` (PR #2902).

## Usage

```ts
const medal = new Medal('medal_xxx');
const { data } = await medal.ai.generate({
  prompt: 'Write a 3-bullet crypto market summary in Arabic.',
  system_prompt: 'You are a precise market analyst.',
  max_tokens: 400,
  use_brand_context: false,
});
console.log(data.text, data.model, data.usage.output_tokens);
```

## Changes

- `src/resources/ai.ts` (`AI` class), `src/types/ai.ts` (`GenerateTextInput`, `GenerateTextResult`); registered on the `Medal` client and re-exported.
- OpenAPI: `/api/v1/ai/generate` operation + `GenerateTextInput`/`GenerateTextResult` schemas + `AI` tag; regenerated `openapi.generated.ts`; coverage map updated (**34 operations**).
- Changeset: **minor**.

## Verification

- `pnpm openapi:check` — lint + types + bundle + coverage OK (34 ops)
- `pnpm typecheck` clean · `pnpm test` 67 passing · `pnpm lint` clean · `pnpm build` + `verify:paths` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
